### PR TITLE
Jung Schema Printer with Spring Boot

### DIFF
--- a/src/main/java/com/activeviam/apps/pivotspringboot/activepivot/SourceConfig.java
+++ b/src/main/java/com/activeviam/apps/pivotspringboot/activepivot/SourceConfig.java
@@ -1,5 +1,6 @@
 package com.activeviam.apps.pivotspringboot.activepivot;
 
+import com.qfs.gui.impl.JungSchemaPrinter;
 import com.qfs.msg.IMessageChannel;
 import com.qfs.msg.csv.*;
 import com.qfs.msg.csv.filesystem.impl.FileSystemCSVTopicFactory;
@@ -106,10 +107,11 @@ public class SourceConfig {
     }
     private void printStoreSizes() {
         // add some logging
-//        if (Boolean.parseBoolean(env.getProperty("schema.printer", "true"))) {
-//            // display the graph
-//            new JungSchemaPrinter(false).print("Datastore", datastore);
-//        }
+        if (Boolean.parseBoolean(env.getProperty("schema.printer", "true"))) {
+            // display the graph
+        	System.setProperty("java.awt.headless", "false");
+            new JungSchemaPrinter(false).print("Datastore", datastore);
+        }
 
         // Print stop watch profiling
         StopWatch.get().printTimings();


### PR DESCRIPTION
Spring boot sets headless to be false which means the Jung Schema printer cannot be rendered.
I've also uncommented the code to print the schema, there's already a property in place to determine if it gets printed or not.